### PR TITLE
Splitting mappings files

### DIFF
--- a/Ontologies.Mappings/src/FillPropertyComparer.cs
+++ b/Ontologies.Mappings/src/FillPropertyComparer.cs
@@ -1,0 +1,52 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="FillPropertyComparer.cs" company="Mapped">
+// Copyright (c) Mapped. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Mapped.Ontologies.Mappings
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Mapped.Ontologies.Mappings.OntologyMapper;
+
+    /// <summary>
+    /// Compares to Property Projections for equality.
+    /// </summary>
+    internal class FillPropertyComparer : IEqualityComparer<FillProperty>
+    {
+        /// <summary>
+        /// Compares two Fill Property objects for equality.
+        /// </summary>
+        /// <param name="x">Input Fill Property 1.</param>
+        /// <param name="y">Input Fill Property 2.</param>
+        /// <returns>Returns true if equal, false if not.</returns>
+        public bool Equals(FillProperty? x, FillProperty? y)
+        {
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            foreach (var inputName in x.InputPropertyNames)
+            {
+                if (!y.InputPropertyNames.Contains(inputName))
+                {
+                    return false;
+                }
+            }
+
+            if (x.OutputPropertyName != y.OutputPropertyName || x.OutputDtmiFilter != y.OutputDtmiFilter)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public int GetHashCode([DisallowNull] FillProperty obj)
+        {
+            return (obj.InputPropertyNames.OrderBy(x => x).ToString() + obj.OutputPropertyName + obj.OutputDtmiFilter).GetHashCode();
+        }
+    }
+}

--- a/Ontologies.Mappings/src/Mappings/v1/Willow/Brick_to_WillowInc.json
+++ b/Ontologies.Mappings/src/Mappings/v1/Willow/Brick_to_WillowInc.json
@@ -1,13 +1,5 @@
 {
   "FillProperties": [
-    {
-      "InputPropertyNames": [
-        "name",
-        "description"
-      ],
-      "OutputDtmiFilter": ".*",
-      "OutputPropertyName": "name"
-    }
   ],
   "Header": {
     "InputOntologies": [
@@ -3874,57 +3866,9 @@
     }
   ],
   "ObjectTransformations": [
-    {
-      "InputProperty": "unit",
-      "InputPropertyName": "id",
-      "OutputDtmiFilter": ".*",
-      "OutputPropertyName": "unit",
-      "Priority": 1
-    }
   ],
   "PropertyProjections": [
-    {
-      "InputPropertyNames": [
-        "mappingKey"
-      ],
-      "IsOutputPropertyCollection": true,
-      "OutputDtmiFilter": ".*",
-      "OutputPropertyName": "externalIds"
-    },
-    {
-      "InputPropertyNames": [
-        "id"
-      ],
-      "IsOutputPropertyCollection": false,
-      "OutputDtmiFilter": ".*",
-      "OutputPropertyName": "externalID"
-    }
   ],
   "RelationshipRemaps": [
-    {
-      "InputRelationship": "floors",
-      "OutputRelationship": "isPartOf",
-      "ReverseRelationshipDirection": true
-    },
-    {
-      "InputRelationship": "hasPart",
-      "OutputRelationship": "isPartOf",
-      "ReverseRelationshipDirection": true
-    },
-    {
-      "InputRelationship": "isLocationOf",
-      "OutputRelationship": "locatedIn",
-      "ReverseRelationshipDirection": true
-    },
-    {
-      "InputRelationship": "hasPoint",
-      "OutputRelationship": "isCapabilityOf",
-      "ReverseRelationshipDirection": true
-    },
-    {
-      "InputRelationship": "serves",
-      "OutputRelationship": "servedBy",
-      "ReverseRelationshipDirection": true
-    }
   ]
 }

--- a/Ontologies.Mappings/src/Mappings/v1/Willow/Brick_to_WillowInc.json
+++ b/Ontologies.Mappings/src/Mappings/v1/Willow/Brick_to_WillowInc.json
@@ -1,0 +1,3930 @@
+{
+  "FillProperties": [
+    {
+      "InputPropertyNames": [
+        "name",
+        "description"
+      ],
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "name"
+    }
+  ],
+  "Header": {
+    "InputOntologies": [
+      {
+        "DtdlVersion": "v2",
+        "Name": "Brick",
+        "Version": "1.0"
+      }
+    ],
+    "OutputOntologies": [
+      {
+        "DtdlVersion": "v3",
+        "Name": "willow",
+        "Version": "1.0"
+      }
+    ]
+  },
+  "InterfaceRemaps": [
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterDeltaPressureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Medium_Temperature_Hot_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Condenser_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingCondenserWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Handling_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirHandlingUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ablutions_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Absorption_Chiller;1",
+      "OutputDtmi": "dtmi:com:willowinc:Chiller;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Acceleration_Time_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AccelerationSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Access_Control_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:AccessControlEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Active_Chilled_Beam;1",
+      "OutputDtmi": "dtmi:com:willowinc:ActiveChilledBeam;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Active_Power_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ActiveElectricalPowerSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Adjust_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirDeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Diffuser;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirDiffuser;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Enthalpy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirEnthalpySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Flow_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Flow_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFlowDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Flow_Demand_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Flow_Loss_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Grains_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Quality_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Static_Pressure_Step_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACAirSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Temperature_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Temperature_Step_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Air_Wet_Bulb_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WetBulbTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Alarm_Delay_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Angle_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AngleSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Atrium;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Auditorium;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Automatic_Mode_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Availability_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Average_Cooling_Demand_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Average_Supply_Air_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Average_Exhaust_Air_Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirStaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Average_Heating_Demand_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Average_Zone_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ZoneAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Basement;1",
+      "OutputDtmi": "dtmi:com:willowinc:BasementLevel;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Battery;1",
+      "OutputDtmi": "dtmi:com:willowinc:BatteryEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Battery_Energy_Storage_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:BatterySystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Battery_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Battery_Voltage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:VoltageSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Bench_Space;1",
+      "OutputDtmi": "dtmi:com:willowinc:Space;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Boiler;1",
+      "OutputDtmi": "dtmi:com:willowinc:Boiler;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Boiler_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Booster_Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Box_Mode_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Break_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Breaker_Panel;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricalPanelboard;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Broadcast_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building;1",
+      "OutputDtmi": "dtmi:com:willowinc:Building;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building_Air_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirHumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building_Air_Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:BuildingAirStaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building_Air_Static_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:BuildingAirStaticPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building_Chilled_Water_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building_Electrical_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricalMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building_Gas_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:GasMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building_Hot_Water_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:ThermalMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:MeterEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Building_Water_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Bypass_Air_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Bypass_Air_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirHumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Bypass_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Bypass_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Bypass_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:BypassHotWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Bypass_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:CO2_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:CO2_Differential_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CO2AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:CO2_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CO2AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:CO2_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CO2Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:CO2_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:CO2Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:CO_Differential_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:COSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:CO_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:COSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:CO_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:COSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Computer_Room_Air_Conditioning;1",
+      "OutputDtmi": "dtmi:com:willowinc:ComputerRoomAirConditioningUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cafeteria;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Camera;1",
+      "OutputDtmi": "dtmi:com:willowinc:VideoSurveillanceCamera;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Capacity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CapacitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ceiling_Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:CeilingFan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Centrifugal_Chiller;1",
+      "OutputDtmi": "dtmi:com:willowinc:Chiller;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Change_Filter_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Beam;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledBeam;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Pressure_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterDeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Pressure_Load_Shed_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Pressure_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterDeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Pressure_Step_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Differential_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeltaChilledWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Pump;1",
+      "OutputDtmi": "dtmi:com:willowinc:DomesticWaterPump;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Static_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:StaticPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACChilledWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_System_Enable_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chilled_Water_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Chiller;1",
+      "OutputDtmi": "dtmi:com:willowinc:Chiller;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Close_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Coil;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanCoilUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cold_Box;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Coldest_Zone_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Collection;1",
+      "OutputDtmi": "dtmi:com:willowinc:Collection;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Collection_Basin_Water_Heater;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterHeater;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Collection_Basin_Water_Level_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Collection_Basin_Water_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LevelSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Collection_Basin_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Common_Space;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Communication_Loss_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Compressor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Compressor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Concession;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condensate_Leak_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeakSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser;1",
+      "OutputDtmi": "dtmi:com:willowinc:Condenser;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser_Heat_Exchanger;1",
+      "OutputDtmi": "dtmi:com:willowinc:HeatExchanger;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser_Water_Bypass_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CondenserWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:CondenserWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser_Water_Isolation_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser_Water_Pump;1",
+      "OutputDtmi": "dtmi:com:willowinc:Pump;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser_Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACCondenserWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CondenserWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condenser_Water_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Condensing_Natural_Gas_Boiler;1",
+      "OutputDtmi": "dtmi:com:willowinc:Boiler;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Conductivity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ConductivitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Conference_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Constant_Air_Volume_Box;1",
+      "OutputDtmi": "dtmi:com:willowinc:CAVBox;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Contact_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ContactSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Control_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Coil;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanCoilUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Demand_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Demand_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Supply_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:CoolingDischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Supply_Air_Temperature_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Supply_Air_Temperature_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Supply_Air_Temperature_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Start_Stop_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:StartState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Tower;1",
+      "OutputDtmi": "dtmi:com:willowinc:CoolingTower;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Tower_Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Copy_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Core_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Core_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cubicle;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Current_Imbalance_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CurrentImbalanceSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Current_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Current_Output_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CurrentSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Current_Ratio_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:CurrentSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Current_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CurrentSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Curtailment_Override_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OverrideActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cycle_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:DC_Bus_Voltage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:VoltageSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Damper_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:DamperActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Damper_Position_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:DamperPositionActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Damper_Position_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DamperPositionSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Damper_Position_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirDamperPositionSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Deceleration_Time_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DwellTimeSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Dedicated_Outdoor_Air_System_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:DedicatedOutdoorAirSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Dehumidification_Start_Stop_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:StartStopState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Deionised_Water_Conductivity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeionizedWaterConductivitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Deionised_Water_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LevelSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Deionized_Water_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Delay_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Demand_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Demand_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Derivative_Gain_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Derivative_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Detention_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Dewpoint_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DewPointTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Dewpoint_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DewPointTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Pressure_Bypass_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Pressure_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirDeltaPressureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Pressure_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Pressure_Load_Shed_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Pressure_Proportional_Band;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Pressure_Step_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Speed_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SpeedSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Speed_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:SpeedSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Differential_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeltaSteamTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Direct_Expansion_Cooling_Coil;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanCoilUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Direct_Expansion_Heating_Coil;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanCoilUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Direction_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Direction_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WindDirectionSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Direction_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Disable_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:DisableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Disable_Differential_Enthalpy_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:DisableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Disable_Differential_Temperature_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:DisableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Disable_Fixed_Enthalpy_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:DisableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Disable_Fixed_Temperature_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:DisableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DisableSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Disable_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Dewpoint_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DewPointTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Flow_Demand_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Flow_High_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Flow_Low_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Flow_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Humidity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirHumiditySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirHumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Smoke_Detection_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Static_Pressure_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Static_Pressure_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirStaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Static_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirStaticPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Static_Pressure_Step_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Cooling_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Heating_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_High_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Low_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Reset_Differential_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Velocity_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirVelocityPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Disconnect_Switch;1",
+      "OutputDtmi": "dtmi:com:willowinc:DisconnectSwitch;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Displacement_Flow_Air_Diffuser;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirDiffuser;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Distribution_Frame;1",
+      "OutputDtmi": "dtmi:com:willowinc:DistributionAsset;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Domestic_Hot_Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:DomesticHotWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Domestic_Hot_Water_System_Enable_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Domestic_Hot_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Domestic_Hot_Water_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Drive_Ready_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Dry_Cooler;1",
+      "OutputDtmi": "dtmi:com:willowinc:DryCooler;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Duration_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DurationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:EconCycle_Start_Stop_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Economizer_Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Effective_Air_Temperature_Cooling_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Effective_Air_Temperature_Heating_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Effective_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Effective_Supply_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Effective_Return_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Effective_Room_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Effective_Zone_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:EffectiveZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Electric_Boiler;1",
+      "OutputDtmi": "dtmi:com:willowinc:Boiler;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Electric_Energy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricalEnergySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Electric_Power_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricalPowerSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Electrical_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricalEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Electrical_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricalMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Electrical_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Electrical_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricalSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Elevator;1",
+      "OutputDtmi": "dtmi:com:willowinc:Elevator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Elevator_Shaft;1",
+      "OutputDtmi": "dtmi:com:willowinc:Space;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Embedded_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Embedded_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Emergency_Air_Flow_System_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Emergency_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Emergency_Generator_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Emergency_Generator_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Emergency_Power_Off_System_Activated_By_High_Temperature_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Emergency_Power_Off_System_Activated_By_Leak_Detection_System_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Emergency_Power_Off_System_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Emergency_Push_Button_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Emergency_Wash_Station;1",
+      "OutputDtmi": "dtmi:com:willowinc:EmergencyEyeWashStation;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Employee_Entrance_Lobby;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enable_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enable_Differential_Enthalpy_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enable_Differential_Temperature_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enable_Fixed_Enthalpy_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enable_Fixed_Temperature_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enable_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enclosed_Office;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Energy_Generation_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:System;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Energy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnergySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Energy_Storage_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricalGenerationStorageEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Energy_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:System;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Energy_Usage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnergySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Energy_Zone;1",
+      "OutputDtmi": "dtmi:com:willowinc:Zone;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Medium_Temperature_Hot_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enthalpy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnthalpySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Enthalpy_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnthalpySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entrance;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Equipment_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Evaporative_Heat_Exchanger;1",
+      "OutputDtmi": "dtmi:com:willowinc:HeatExchanger;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Even_Month_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exercise_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Dewpoint_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DewPointTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirDeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Flow_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Flow_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Humidity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirHumiditySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirHumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Stack_Flow_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Stack_Flow_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Stack_Flow_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Stack_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Stack_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Static_Pressure_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirStaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Static_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirStaticPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Air_Velocity_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirVelocityPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Exhaust_Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustFan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Eye_Wash_Station;1",
+      "OutputDtmi": "dtmi:com:willowinc:EmergencyEyeWashStation;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan_Coil_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanCoilUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Failure_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan_On_Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan_Speed_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanSpeedActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanRunState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan_VFD;1",
+      "OutputDtmi": "dtmi:com:willowinc:VariableFrequencyDrive;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fault_Reset_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:FaultResetActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fault_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:FaultState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Filter;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFilter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Filter_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:FilterAirDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Filter_Reset_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Filter_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Final_Filter;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFilter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fire_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fire_Control_Panel;1",
+      "OutputDtmi": "dtmi:com:willowinc:FireAlarmControlPanel;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fire_Safety_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:FireProtectionEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fire_Safety_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:FireProtectionSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fire_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:FireSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fire_Zone;1",
+      "OutputDtmi": "dtmi:com:willowinc:Zone;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:First_Aid_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Floor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Level;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:FlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:FlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Food_Service_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Formaldehyde_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CH2OAirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Freeze_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Freezer;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Frequency_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Frequency_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:FrequencySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Frequency_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:FrequencySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fresh_Air_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Frost_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fume_Hood;1",
+      "OutputDtmi": "dtmi:com:willowinc:VentilationHood;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fume_Hood_Air_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Gain_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Gas_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:GasMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Gas_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Gas_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:GasSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Gas_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Generator_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:HVAC_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Ventilation_Air_Conditioning_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:HVAC_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACValve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:HVAC_Zone;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACZone;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hail_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hallway;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hazardous_Materials_Storage;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heat_Exchanger;1",
+      "OutputDtmi": "dtmi:com:willowinc:HeatExchanger;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heat_Exchanger_System_Enable_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heat_Recovery_Hot_Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACHotWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heat_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heat_Sink_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heat_Wheel_VFD;1",
+      "OutputDtmi": "dtmi:com:willowinc:VariableFrequencyDrive;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Coil;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanCoilUnitReheat;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:HeatingActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Demand_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Demand_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Supply_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HeatingDischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Supply_Air_Temperature_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Supply_Air_Temperature_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Start_Stop_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:StartStopState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Supply_Air_Temperature_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Thermal_Power_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ThermalPowerSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Heating_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Air_Flow_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_CO2_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Supply_Air_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Head_Pressure_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Humidity_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Humidity_Alarm_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Outside_Air_Lockout_Temperature_Differential_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Return_Air_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Static_Pressure_Cutout_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:High_Temperature_Alarm_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hold_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Differential_Pressure_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterDeltaPressureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Differential_Pressure_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Differential_Pressure_Load_Shed_Reset_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Differential_Pressure_Load_Shed_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Differential_Pressure_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterDeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Differential_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeltaHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Pump;1",
+      "OutputDtmi": "dtmi:com:willowinc:Pump;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Static_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:StaticPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACHotWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_System_Enable_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Usage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Hot_Water_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidification_Start_Stop_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:StartStopState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidifier;1",
+      "OutputDtmi": "dtmi:com:willowinc:Humidifier;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidifier_Fault_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:FaultState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidify_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidity_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidity_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidity_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:HumiditySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Humidity_Tolerance_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:IDF;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ice_Tank_Leaving_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Illuminance_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:IlluminanceSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Imbalance_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Information_Area;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Inside_Face_Surface_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Inside_Face_Surface_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Intake_Air_Filter;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFilter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Intake_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:InletAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Integral_Gain_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Intrusion_Detection_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:IntrusionDetectionEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Inverter;1",
+      "OutputDtmi": "dtmi:com:willowinc:EmergencyLightingPowerInverter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Isolation_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Janitor_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Jet_Nozzle_Air_Diffuser;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirDiffuser;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Laboratory;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Laminar_Flow_Air_Diffuser;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirDiffuser;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Last_Fault_Code_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:FaultState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lead_Lag_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lead_Lag_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lead_On_Off_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OffActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leak_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeakSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Library;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Light_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lighting;1",
+      "OutputDtmi": "dtmi:com:willowinc:LightingEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lighting_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:LightingEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lighting_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:LightingSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lighting_Zone;1",
+      "OutputDtmi": "dtmi:com:willowinc:LightingZone;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Liquid_Detection_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Load_Current_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CurrentSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Load_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Load_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LoadLevelSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Load_Shed_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Load_Shed_Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Load_Shed_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Load_Shed_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Loading_Dock;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lobby;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Locally_On_Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lockout_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:LockoutState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lockout_Temperature_Differential_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lounge;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Air_Flow_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Battery_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReplaceBatteryState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Supply_Air_Flow_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Supply_Air_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Freeze_Protect_Temperature_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Humidity_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Humidity_Alarm_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Outside_Air_Lockout_Temperature_Differential_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Outside_Air_Temperature_Enable_Differential_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Outside_Air_Temperature_Enable_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Return_Air_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Suction_Pressure_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Temperature_Alarm_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Low_Voltage_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Lowest_Exhaust_Air_Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ExhaustAirStaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Luminaire;1",
+      "OutputDtmi": "dtmi:com:willowinc:Luminaire;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Luminance_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Luminance_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Luminance_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LuminanceSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Luminance_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LuminanceSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mail_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Maintenance_Mode_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Maintenance_Required_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Makeup_Air_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MakeupAirUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Makeup_Water_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Manual_Auto_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Massage_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Chilled_Water_Differential_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Supply_Air_Static_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Frequency_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Hot_Water_Differential_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Load_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Position_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Speed_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Static_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Supply_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Water_Level_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Max_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mechanical_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Media_Production_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Media_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Medical_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Medium_Temperature_Hot_Water_Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterDeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:MeterEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Methane_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LevelSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Chilled_Water_Differential_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Supply_Air_Static_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Fresh_Air_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Hot_Water_Differential_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Outside_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Position_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Speed_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Static_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Supply_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Water_Level_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Min_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mixed_Air_Filter;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFilter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mixed_Air_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:MixedAirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mixed_Air_Humidity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:MixedAirHumiditySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mixed_Air_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:MixedAirHumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mixed_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:MixedAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mixed_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:MixedAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mixed_Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mode_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Motion_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:MotionSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Motor_Control_Center;1",
+      "OutputDtmi": "dtmi:com:willowinc:MotorControlCenter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Motor_Current_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CurrentSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Motor_Direction_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Motor_On_Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Motor_Speed_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SpeedSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Motor_Torque_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TorqueSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:NO2_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:NO2Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Natural_Gas_Boiler;1",
+      "OutputDtmi": "dtmi:com:willowinc:Boiler;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Natural_Gas_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:NaturalGasMassFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Natural_Gas_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Natural_Gas_Usage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Network_Video_Recorder;1",
+      "OutputDtmi": "dtmi:com:willowinc:VideoSurveillanceNVR;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:No_Water_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Noncondensing_Natural_Gas_Boiler;1",
+      "OutputDtmi": "dtmi:com:willowinc:Boiler;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupancy_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupiedActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupancy_Count_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PeopleCountSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupancy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupancySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupancy_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupiedState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Cooling_Supply_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Cooling_Temperature_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Cooling_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupiedCoolingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Supply_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Heating_Supply_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Heating_Temperature_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Heating_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupiedHeatingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupiedState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Return_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Room_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Supply_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Zone_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Off_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OffActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Office;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Office_Kitchen;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:On_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:On_Off_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:On_Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:On_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Open_Close_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OpenCloseState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Open_Office;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Operating_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outdoor_Area;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutdoorArea;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Output_Frequency_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:FrequencySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Output_Voltage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:VoltageSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside;1",
+      "OutputDtmi": "dtmi:com:willowinc:Space;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_CO2_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirQualityCO2Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_CO_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirCOSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Dewpoint_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DewPointTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Enthalpy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirEnthalpySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Grains_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Humidity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirHumiditySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirHumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Lockout_Temperature_Differential_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Lockout_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirTemperatureLockoutSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Temperature_Enable_Differential_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Temperature_High_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Temperature_Low_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Air_Wet_Bulb_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WetBulbTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Face_Surface_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Face_Surface_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Outside_Illuminance_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:OutsideIlluminanceSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Overload_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Overridden_Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OverrideState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Overridden_On_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OverrideState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Overridden_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OverrideState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Override_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OverrideActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ozone_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:O3AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PID_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PIR_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PresenceSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PM10_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PM10AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PM10_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PM10AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PM1_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PM001AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PM1_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PM001AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PM25_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PM025AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PVT_Panel;1",
+      "OutputDtmi": "dtmi:com:willowinc:PhotovoltaicPanel;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Photovoltaic_Current_Output_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CurrentSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PV_Panel;1",
+      "OutputDtmi": "dtmi:com:willowinc:PhotovoltaicPanel;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Parking_Level;1",
+      "OutputDtmi": "dtmi:com:willowinc:Level;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Parking_Space;1",
+      "OutputDtmi": "dtmi:com:willowinc:ParkingSpot;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Parking_Structure;1",
+      "OutputDtmi": "dtmi:com:willowinc:StructuralBuildingComponent;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Particulate_Matter_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Passive_Chilled_Beam;1",
+      "OutputDtmi": "dtmi:com:willowinc:PassiveChilledBeam;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Piezoelectric_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Plumbing_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Point;1",
+      "OutputDtmi": "dtmi:com:willowinc:Capability;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Portfolio;1",
+      "OutputDtmi": "dtmi:com:willowinc:Portfolio;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Position_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:PositionActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Position_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Position_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PositionSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Power_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Power_Factor_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PowerFactorSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Power_Loss_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Power_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PowerSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Prayer_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pre_Filter;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFilter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pre_Filter_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Preheat_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:PreheatLevelActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Preheat_Demand_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Preheat_Supply_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Preheat_Hot_Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACHotWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Preheat_Hot_Water_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pressure_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:PressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pressure_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Private_Office;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Proportional_Gain_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pump;1",
+      "OutputDtmi": "dtmi:com:willowinc:Pump;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pump_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:PumpActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pump_On_Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pump_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pump_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:PumpRunState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Pump_VFD;1",
+      "OutputDtmi": "dtmi:com:willowinc:VariableFrequencyDrive;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Rooftop_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:RooftopUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Radiant_Panel_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Radiant_Panel_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Radiation_Hot_Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACHotWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Radioactivity_Concentration_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Radon_Concentration_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Rain_Duration_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DurationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Rated_Speed_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:SpeedSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Reactive_Energy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReactiveElectricalEnergySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Reactive_Power_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReactiveElectricalPowerSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Reception;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Region;1",
+      "OutputDtmi": "dtmi:com:willowinc:Region;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Reheat_Hot_Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACHotWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Reheat_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Relative_Humidity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:RelativeHumiditySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Relay_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Relief_Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Relief_Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Remotely_On_Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Reset_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Rest_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Retail_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_CO2_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirQualityCO2Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_CO2_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirCO2Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_CO_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirCOSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Dewpoint_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DewPointTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirDeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Enthalpy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirEnthalpySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Filter;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFilter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Grains_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Humidity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirHumiditySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirHumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Temperature_High_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Temperature_Low_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnFan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Return_Heating_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Rooftop;1",
+      "OutputDtmi": "dtmi:com:willowinc:RoofLevel;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Room_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Run_Enable_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Run_Request_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:RunState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Run_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:RunState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Safety_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:SafetyEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Safety_Shower;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Safety_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:System;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Sash_Position_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PositionSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Schedule_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Security_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:SecurityEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Security_Service_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Sensor_Failure_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Server_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Service_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Shared_Office;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Short_Cycle_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Shower;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Site;1",
+      "OutputDtmi": "dtmi:com:willowinc:Land;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Smoke_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Smoke_Detection_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Soil_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Solar_Azimuth_Angle_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SolarAzimuthAngleSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Solar_Radiance_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SolarIrradianceSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Solar_Zenith_Angle_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SolarZenithAngleSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Space;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Space_Heater;1",
+      "OutputDtmi": "dtmi:com:willowinc:UnitHeater;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Speed_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Speed_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Speed_Reset_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Speed_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SpeedSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Speed_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:SpeedSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Speed_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Speed_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Sports_Service_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Stage_Enable_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Stages_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Staircase;1",
+      "OutputDtmi": "dtmi:com:willowinc:Stairway;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Standby_CRAC;1",
+      "OutputDtmi": "dtmi:com:willowinc:ComputerRoomAirConditioningUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Standby_Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Standby_Glycool_Unit_On_Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Standby_Load_Shed_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Standby_Unit_On_Off_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Start_Stop_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:StartStopActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Start_Stop_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:StartStopState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Static_Pressure_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirStaticPressureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Static_Pressure_Integral_Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Static_Pressure_Proportional_Band_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:StaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Static_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:StaticPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Static_Pressure_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Static_Pressure_Step_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Steam_On_Off_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Steam_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:SteamSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Steam_Usage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Steam_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Step_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Storage_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Studio;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Duct_Pressure_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Integral_Gain_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Proportional_Gain_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Static_Pressure_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirStaticPressureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureDeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Temperature_Step_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:SupplyFan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Surveillance_Camera;1",
+      "OutputDtmi": "dtmi:com:willowinc:VideoSurveillanceCamera;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Switch;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricalSwitch;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Switch_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Switch_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Switchgear;1",
+      "OutputDtmi": "dtmi:com:willowinc:Switchgear;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:System;1",
+      "OutputDtmi": "dtmi:com:willowinc:System;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:System_Enable_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:System_Shutdown_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:System_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:TETRA_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:TVOC_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TVOCSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:TVOC_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TVOCSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Team_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Telecom_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Adjust_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Differential_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_High_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Low_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Step_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temperature_Tolerance_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Temporary_Occupancy_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Terminal_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:TerminalUnit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Thermal_Power_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:ThermalMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Thermal_Power_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ThermalPowerSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Thermostat;1",
+      "OutputDtmi": "dtmi:com:willowinc:ThermostatEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Thermostat_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Thermostatic_Mixing_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ticketing_Booth;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Time_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Time_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TimeSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Tint_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Tolerance_Parameter;1",
+      "OutputDtmi": "dtmi:com:willowinc:Parameter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Torque_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TorqueSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Trace_Heat_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Transfer_Fan;1",
+      "OutputDtmi": "dtmi:com:willowinc:TransferFan;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Transformer;1",
+      "OutputDtmi": "dtmi:com:willowinc:Transformer;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Transformer_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Tunnel;1",
+      "OutputDtmi": "dtmi:com:willowinc:Tunnel;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Underfloor_Air_Plenum_Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:StaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Underfloor_Air_Plenum_Static_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:StaticPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Underfloor_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unit_Failure_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Air_Temperature_Cooling_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:UnoccupiedCoolingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Air_Temperature_Heating_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:UnoccupiedHeatingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Cooling_Supply_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:CoolingDischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Cooling_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Supply_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Heating_Supply_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HeatingDischargeAirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Load_Shed_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:UnoccupiedActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Return_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:InletAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Room_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Zone_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Usage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Variable_Air_Volume_Box;1",
+      "OutputDtmi": "dtmi:com:willowinc:VAVBox;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Variable_Frequency_Drive;1",
+      "OutputDtmi": "dtmi:com:willowinc:VariableFrequencyDrive;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:VFD_Enable_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnableActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Valve_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Valve_Position_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Valve_Position_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:ValvePositionActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Valve_Position_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ValvePositionSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Valve_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Velocity_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:VelocityPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Velocity_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:PressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Vent_Operating_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ventilation_Air_Flow_Ratio_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Limit;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Vertical_Space;1",
+      "OutputDtmi": "dtmi:com:willowinc:Space;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Video_Surveillance_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:VideoSurveillanceEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Visitor_Lobby;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Voltage_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Voltage_Imbalance_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:VoltageImbalanceSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Voltage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:VoltageSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Wardrobe;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Warm_Cool_Adjust_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Warmest_Zone_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterDeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Differential_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Differential_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Heater;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterHeater;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Level_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LevelSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Loss_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Pump;1",
+      "OutputDtmi": "dtmi:com:willowinc:DomesticWaterPump;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Tank;1",
+      "OutputDtmi": "dtmi:com:willowinc:Tank;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Temperature_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Usage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Water_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:Valve;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Weather_Station;1",
+      "OutputDtmi": "dtmi:com:willowinc:WeatherStationEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Wind_Direction_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WindDirectionSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Wind_Speed_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WindSpeedSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Wing;1",
+      "OutputDtmi": "dtmi:com:willowinc:ArchitecturalBuildingComponent;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone;1",
+      "OutputDtmi": "dtmi:com:willowinc:Zone;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Air_Cooling_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:CoolingZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Air_Dewpoint_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DewPointTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Air_Heating_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HeatingZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Air_Humidity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ZoneAirHumiditySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Air_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ZoneAirHumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Air_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ZoneAirTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Standby_Load_Shed_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Zone_Unoccupied_Load_Shed_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:UnoccupiedActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Chilled_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringChilledWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Chilled_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingChilledWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Condenser_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingCondenserWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Supply_Air_Differential_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirDeltaPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Chilled_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringChilledWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Chilled_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringChilledWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Condenser_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringCondenserWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Hot_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringHotWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Hot_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringHotWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Chilled_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingChilledWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Chilled_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingChilledWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Condenser_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingCondenserWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Hot_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Hot_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Occupied_Air_Temperature_Heating_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupiedHeatingZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PM25_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PM025AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Chilled_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:SecondaryLoopEnteringChilledWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Hot_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Hot_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Condenser_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringCondenserWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Condenser_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringCondenserWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Entering_Hot_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Leaving_Chilled_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingChilledWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Cooling_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:UnoccupiedCoolingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Unoccupied_Heating_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:UnoccupiedHeatingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Access_Reader;1",
+      "OutputDtmi": "dtmi:com:willowinc:AccessReader;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Intercom_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:Equipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:PV_Generation_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:System;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:On_Timer_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TimeSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Shading_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:System;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Solar_Thermal_Collector;1",
+      "OutputDtmi": "dtmi:com:willowinc:ThermalMeter;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Ventilation_Air_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:System;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Electric_Baseboard_Radiator;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricBaseboardHeater;1"
+    }
+  ],
+  "NamespaceRemaps": [
+    {
+      "InputNamespace": "dtmi:org:brickschema:schema:Brick:",
+      "OutputNamespace": "dtmi:com:willowinc:"
+    }
+  ],
+  "ObjectTransformations": [
+    {
+      "InputProperty": "unit",
+      "InputPropertyName": "id",
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "unit",
+      "Priority": 1
+    }
+  ],
+  "PropertyProjections": [
+    {
+      "InputPropertyNames": [
+        "mappingKey"
+      ],
+      "IsOutputPropertyCollection": true,
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "externalIds"
+    },
+    {
+      "InputPropertyNames": [
+        "id"
+      ],
+      "IsOutputPropertyCollection": false,
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "externalID"
+    }
+  ],
+  "RelationshipRemaps": [
+    {
+      "InputRelationship": "floors",
+      "OutputRelationship": "isPartOf",
+      "ReverseRelationshipDirection": true
+    },
+    {
+      "InputRelationship": "hasPart",
+      "OutputRelationship": "isPartOf",
+      "ReverseRelationshipDirection": true
+    },
+    {
+      "InputRelationship": "isLocationOf",
+      "OutputRelationship": "locatedIn",
+      "ReverseRelationshipDirection": true
+    },
+    {
+      "InputRelationship": "hasPoint",
+      "OutputRelationship": "isCapabilityOf",
+      "ReverseRelationshipDirection": true
+    },
+    {
+      "InputRelationship": "serves",
+      "OutputRelationship": "servedBy",
+      "ReverseRelationshipDirection": true
+    }
+  ]
+}

--- a/Ontologies.Mappings/src/Mappings/v1/Willow/Mapped.Core_to_WillowInc.json
+++ b/Ontologies.Mappings/src/Mappings/v1/Willow/Mapped.Core_to_WillowInc.json
@@ -1110,31 +1110,8 @@
     }
   ],
   "ObjectTransformations": [
-    {
-      "InputProperty": "unit",
-      "InputPropertyName": "id",
-      "OutputDtmiFilter": ".*",
-      "OutputPropertyName": "unit",
-      "Priority": 1
-    }
   ],
   "PropertyProjections": [
-    {
-      "InputPropertyNames": [
-        "mappingKey"
-      ],
-      "IsOutputPropertyCollection": true,
-      "OutputDtmiFilter": ".*",
-      "OutputPropertyName": "externalIds"
-    },
-    {
-      "InputPropertyNames": [
-        "id"
-      ],
-      "IsOutputPropertyCollection": false,
-      "OutputDtmiFilter": ".*",
-      "OutputPropertyName": "externalID"
-    }
   ],
   "RelationshipRemaps": [
   ]

--- a/Ontologies.Mappings/src/Mappings/v1/Willow/Mapped.Core_to_WillowInc.json
+++ b/Ontologies.Mappings/src/Mappings/v1/Willow/Mapped.Core_to_WillowInc.json
@@ -1,0 +1,1141 @@
+{
+  "FillProperties": [
+    {
+      "InputPropertyNames": [
+        "name",
+        "description"
+      ],
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "name"
+    }
+  ],
+  "Header": {
+    "InputOntologies": [
+      {
+        "DtdlVersion": "v2",
+        "Name": "mapped.core",
+        "Version": "1.0"
+      }
+    ],
+    "OutputOntologies": [
+      {
+        "DtdlVersion": "v3",
+        "Name": "willow",
+        "Version": "1.0"
+      }
+    ]
+  },
+  "InterfaceRemaps": [
+    {
+      "InputDtmi": "dtmi:mapped:core:Absolute_Humidity_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AbsoluteHumiditySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Access_Activity_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:StateSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Access_Card_Reader;1",
+      "OutputDtmi": "dtmi:com:willowinc:AccessReader;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Access_Control_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:AccessControlSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Access_Control_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:AccessControlEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Access_Control_Zone;1",
+      "OutputDtmi": "dtmi:com:willowinc:Zone;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Active_Energy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TotalNetActiveElectricalEnergySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Active_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Active_Zone_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Address;1",
+      "OutputDtmi": "dtmi:com:willowinc:Address;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Air_Flow_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Air_Flow_Direction_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Air_Flow_Rate_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Air_Flow_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Air_Quality_Sensing_Device;1",
+      "OutputDtmi": "dtmi:com:willowinc:IAQSensorEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Altitude_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Ante_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Area_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:AreaSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Audio_Gain_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Auxiliary_Heat_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Auxiliary_Heater_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:BACnet_Device;1",
+      "OutputDtmi": "dtmi:com:willowinc:Equipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Battery_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Bio_Containment_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Equipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Booster_Pump;1",
+      "OutputDtmi": "dtmi:com:willowinc:Pump;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Bypass_Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:CO2_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:CO_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Calendar_Event;1",
+      "OutputDtmi": "dtmi:com:willowinc:Event;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Ceiling_Height_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:HeightSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chilled_Refrigerant_Supply_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:RefrigerantTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chilled_Water_Discharge_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chilled_Water_Discharge_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chilled_Water_Return_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingChilledWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chilled_Water_Return_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringChilledWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chilled_Water_Supply_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chilled_Water_Supply_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chilled_Water_Supply_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingChilledWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chilled_Water_Usage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:QuantitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Close_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:CloseActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Close_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:CloseState;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Coefficient_Of_Performance_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:CoefficientOfPerformance;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Compressor_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Condenser_Water_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CondenserWaterDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Condenser_Water_Flow_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:CondenserWaterPumpRunActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Condenser_Water_Flow_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Connected_Access_Point_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OperationalState;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Connected_Devices_Count_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:CountSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Controller;1",
+      "OutputDtmi": "dtmi:com:willowinc:Controller;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Cooling_Air_Temperature_Setpoint_Offset;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Cooling_Request_Count_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Cooling_Thermal_Energy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ThermalEnergySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Cooling_Thermal_Power_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CoolingLevelSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Correlated_Color_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Count;1",
+      "OutputDtmi": "dtmi:com:willowinc:CountSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Current_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Dehumidification_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Dehumidify_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Device;1",
+      "OutputDtmi": "dtmi:com:willowinc:Equipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Differential_Air_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Differential_Pressure_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Differential_Supply_Return_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Discharge_Air_Temperature_High_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Discharge_Air_Temperature_Low_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Discharge_Air_Temperature_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Discharge_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Discharge_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Discharge_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Display_Resolution_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Display_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Domestic_Hot_Water_Differential_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeltaHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Domestic_Hot_Water_Supply_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Domestic_Hot_Water_Supply_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Door;1",
+      "OutputDtmi": "dtmi:com:willowinc:Door;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Drain_Pan_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Duct_Air_Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirStaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Duct_Static_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:StaticPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Economizer_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Effective_Cooling_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:EffectiveCoolingZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Effective_Heating_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Effective_Occupied_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Electric_Energy_Usage_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:BilledNetActiveElectricalEnergy;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Emergency_Recovery_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Equipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Energy_Density_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:DensitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Entry;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Entry_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Environment_Index_Satisfied_Time_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Evaporator_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Evaporator_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Evapotranspiration_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Event;1",
+      "OutputDtmi": "dtmi:com:willowinc:Event;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Filter_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Floor_Level;1",
+      "OutputDtmi": "dtmi:com:willowinc:Level;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Fuel_Moisture_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:QuantitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Fuel_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Furniture;1",
+      "OutputDtmi": "dtmi:com:willowinc:Furniture;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Geo_Location_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Grease_Trap;1",
+      "OutputDtmi": "dtmi:com:willowinc:GreaseTrap;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Grease_Trap_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LevelSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:H2S_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LevelSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Heat_Exchanger_Return_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CoilEnteringWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Heat_Exchanger_Supply_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Heating_Request_Count_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Heating_Thermal_Energy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ThermalEnergySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:High_Humidity_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:High_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:High_Static_Pressure_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:High_TVOC_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:High_Temperature_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:High_Temperature_Hot_Water_Return_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:High_Temperature_Hot_Water_Supply_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:High_Voltage_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Hot_Water_Discharge_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Hot_Water_Discharge_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Hot_Water_Return_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringHotWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Hot_Water_Return_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnteringHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Hot_Water_Supply_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Hot_Water_Supply_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Hot_Water_Supply_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Humidity_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:ICT_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:ICTEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Ice_Tank_Entering_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Ignition_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Lighting_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Lighting_Controller;1",
+      "OutputDtmi": "dtmi:com:willowinc:LightingController;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Lighting_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Location_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Lock_Unlock_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OnOffActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Low_Humidity_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Low_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Low_Static_Air_Pressure_Alarm;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Low_Temperature_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AlarmSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Max_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Max_Cooling_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Max_Cooling_Discharge_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Max_Heating_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Max_Power_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MaxLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Medium_Temperature_Hot_Water_Return_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:LeavingHotWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Min_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Min_Cooling_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Min_Cooling_Supply_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Min_Heating_Air_Temperature_Setpoint_Limit;1",
+      "OutputDtmi": "dtmi:com:willowinc:MinLimit;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Mute_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:NO_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Natural_Gas_Seismic_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACShutOffValve;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:O2_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:O2AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Occupancy_Sensing_Device;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupancySensorEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Occupancy_Zone;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupancyZone;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Occupied_Cooling_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupiedCoolingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Occupied_Heating_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:OccupiedHeatingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Offset;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Open_Close_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OpenCloseActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Open_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:OpenActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Open_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:OpenPositionState;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Outside_Air_Temperature_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Person;1",
+      "OutputDtmi": "dtmi:com:willowinc:Person;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Place;1",
+      "OutputDtmi": "dtmi:com:willowinc:Space;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_Accumulation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationAccumulationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_Accumulation_Since_Midnight_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationAccumulationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_Fifteen_Minutes_Accumulation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationAccumulationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_One_Hour_Accumulation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationAccumulationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_One_Minute_Accumulation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationAccumulationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationRateSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_Ten_Minutes_Accumulation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationAccumulationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_Thirty_Minutes_Accumulation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationAccumulationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_Three_Hours_Accumulation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationAccumulationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Precipitation_Twentyfour_Hours_Accumulation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PrecipitationAccumulationSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Pressure_High_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:PressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Pressure_Low_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:PressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Pressure_Request_Count_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Real_Energy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:EnergySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Refrigerant_Saturation_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Refrigerant_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:RefrigerantTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Relative_Humidity_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:RelativeHumiditySetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Relay_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Request_Count_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Reset_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Air_Velocity_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirVelocityPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Air_Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ReturnAirStaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Air_Temperature_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ResetSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Chilled_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Condenser_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CondenserWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Condenser_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CondenserWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Evaporator_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Hot_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:HotWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Water_Temperature_Deadband_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DeadbandSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Return_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Road_Subsurface_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Run_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:RunActuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:SO2_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SO2AirQualitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Schedule_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Scheduled_Occupied_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:ModeState;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Screen_Orientation_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Sea_Level_Air_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Security_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:SecuritySystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Sensor_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:SensorEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Sensor_Type_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:StatusSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Setpoint_Offset;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Snow_Accumulation_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:QuantitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Sound_Pressure_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SoundPressureLevelSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Sound_Volume_Level_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Standby_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Standby_Cooling_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:StandbyCoolingZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Standby_Heating_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:StandbyHeatingZoneAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Steam_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:FlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Steam_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SteamPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Steam_Pressure_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:SteamPressureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Suction_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:PressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Superheat_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Supply_Air_Duct_Static_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirStaticPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Supply_Air_Temperature_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:DischargeAirTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Supply_Chilled_Water_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterTemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Supply_Condenser_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CondenserWaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Supply_Condenser_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:CondenserWaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Supply_Evaporator_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Supply_Water_Flow_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Supply_Water_Flow_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterFlowSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Supply_Water_Temperature_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterTemperatureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Symbolic_Location_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Teleconference_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:Equipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Temperature_Alarm_Count;1",
+      "OutputDtmi": "dtmi:com:willowinc:CountSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Temperature_Alarm_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:TemperatureSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Test_Point;1",
+      "OutputDtmi": "dtmi:com:willowinc:Capability;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Thermal_Energy_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:ThermalEnergySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Thing;1",
+      "OutputDtmi": "dtmi:com:willowinc:Asset;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Time_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:TimeSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:UV_Lighting_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Unoccupied_Cooling_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:UnoccupiedCoolingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Unoccupied_Heating_Air_Temperature_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:UnoccupiedHeatingSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Valve_Percentage_Command;1",
+      "OutputDtmi": "dtmi:com:willowinc:Actuator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Valve_Position_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:ValvePositionSetpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Visibility_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:VisibilitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Waste_Amount_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:QuantitySensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Water_Differential_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterDeltaPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Water_Pressure_High_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Water_Pressure_Low_Reset_Setpoint;1",
+      "OutputDtmi": "dtmi:com:willowinc:Setpoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Weather_Condition_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Wheel_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Wind_Gust_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:Sensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Window_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Zone_Conditioning_Mode_Status;1",
+      "OutputDtmi": "dtmi:com:willowinc:State;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Isolation_Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Operating_Room;1",
+      "OutputDtmi": "dtmi:com:willowinc:Room;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Person_Profile;1",
+      "OutputDtmi": "dtmi:com:willowinc:Person;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Waste_Meter;1",
+      "OutputDtmi": "dtmi:com:willowinc:MeterEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Wireless_Access_Point;1",
+      "OutputDtmi": "dtmi:com:willowinc:WirelessAccessPoint;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Air_Compressor_Dryer;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirCompressorDryer;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Plumbing_Valve;1",
+      "OutputDtmi": "dtmi:com:willowinc:PlumbingValve;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Air_Compressor;1",
+      "OutputDtmi": "dtmi:com:willowinc:AirCompressor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Fan_Powered_Terminal_Unit;1",
+      "OutputDtmi": "dtmi:com:willowinc:FanPoweredBox;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Fire_Damper;1",
+      "OutputDtmi": "dtmi:com:willowinc:FireDamper;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Switchboard;1",
+      "OutputDtmi": "dtmi:com:willowinc:Switchboard;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Uninterruptible_Power_Supply;1",
+      "OutputDtmi": "dtmi:com:willowinc:UPS;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Plumbing_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:PlumbingSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Plumbing_Pump;1",
+      "OutputDtmi": "dtmi:com:willowinc:PlumbingPump;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:HVAC_Pump;1",
+      "OutputDtmi": "dtmi:com:willowinc:HVACPump;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Electric_Unit_Heater;1",
+      "OutputDtmi": "dtmi:com:willowinc:ElectricUnitHeater;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Generator;1",
+      "OutputDtmi": "dtmi:com:willowinc:Generator;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Automatic_Transfer_Switch;1",
+      "OutputDtmi": "dtmi:com:willowinc:AutomaticTransferSwitch;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Tank;1",
+      "OutputDtmi": "dtmi:com:willowinc:Tank;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Rain_Level_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:RainfallRateSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Plumbing_Equipment;1",
+      "OutputDtmi": "dtmi:com:willowinc:PlumbingEquipment;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Solar_Irradiance_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:SolarIrradianceSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Domestic_Cold_Water_System;1",
+      "OutputDtmi": "dtmi:com:willowinc:DomesticColdWaterSystem;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Water_Pressure_Sensor;1",
+      "OutputDtmi": "dtmi:com:willowinc:WaterPressureSensor;1"
+    },
+    {
+      "InputDtmi": "dtmi:mapped:core:Chiller_Plant;1",
+      "OutputDtmi": "dtmi:com:willowinc:ChilledWaterPlant;1"
+    }
+  ],
+  "NamespaceRemaps": [
+    {
+      "InputNamespace": "dtmi:mapped:core:",
+      "OutputNamespace": "dtmi:com:willowinc:"
+    }
+  ],
+  "ObjectTransformations": [
+    {
+      "InputProperty": "unit",
+      "InputPropertyName": "id",
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "unit",
+      "Priority": 1
+    }
+  ],
+  "PropertyProjections": [
+    {
+      "InputPropertyNames": [
+        "mappingKey"
+      ],
+      "IsOutputPropertyCollection": true,
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "externalIds"
+    },
+    {
+      "InputPropertyNames": [
+        "id"
+      ],
+      "IsOutputPropertyCollection": false,
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "externalID"
+    }
+  ],
+  "RelationshipRemaps": [
+  ]
+}

--- a/Ontologies.Mappings/src/Mappings/v1/Willow/Mapped_to_WillowInc_Generic.json
+++ b/Ontologies.Mappings/src/Mappings/v1/Willow/Mapped_to_WillowInc_Generic.json
@@ -1,0 +1,86 @@
+{
+  "FillProperties": [
+    {
+      "InputPropertyNames": [
+        "name",
+        "description"
+      ],
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "name"
+    }
+  ],
+  "Header": {
+    "InputOntologies": [
+      {
+        "DtdlVersion": "v2",
+        "Name": "Mapped",
+        "Version": "1.0"
+      }
+    ],
+    "OutputOntologies": [
+      {
+        "DtdlVersion": "v3",
+        "Name": "willow",
+        "Version": "1.0"
+      }
+    ]
+  },
+  "InterfaceRemaps": [
+  ],
+  "NamespaceRemaps": [
+  ],
+  "ObjectTransformations": [
+    {
+      "InputProperty": "unit",
+      "InputPropertyName": "id",
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "unit",
+      "Priority": 1
+    }
+  ],
+  "PropertyProjections": [
+    {
+      "InputPropertyNames": [
+        "mappingKey"
+      ],
+      "IsOutputPropertyCollection": true,
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "externalIds"
+    },
+    {
+      "InputPropertyNames": [
+        "id"
+      ],
+      "IsOutputPropertyCollection": false,
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "externalID"
+    }
+  ],
+  "RelationshipRemaps": [
+    {
+      "InputRelationship": "floors",
+      "OutputRelationship": "isPartOf",
+      "ReverseRelationshipDirection": true
+    },
+    {
+      "InputRelationship": "hasPart",
+      "OutputRelationship": "isPartOf",
+      "ReverseRelationshipDirection": true
+    },
+    {
+      "InputRelationship": "isLocationOf",
+      "OutputRelationship": "locatedIn",
+      "ReverseRelationshipDirection": true
+    },
+    {
+      "InputRelationship": "hasPoint",
+      "OutputRelationship": "isCapabilityOf",
+      "ReverseRelationshipDirection": true
+    },
+    {
+      "InputRelationship": "serves",
+      "OutputRelationship": "servedBy",
+      "ReverseRelationshipDirection": true
+    }
+  ]
+}

--- a/Ontologies.Mappings/src/Mappings/v1/Willow/Rec_to_WillowInc.json
+++ b/Ontologies.Mappings/src/Mappings/v1/Willow/Rec_to_WillowInc.json
@@ -1,0 +1,50 @@
+{
+  "FillProperties": [
+    {
+      "InputPropertyNames": [
+        "name",
+        "description"
+      ],
+      "OutputDtmiFilter": ".*",
+      "OutputPropertyName": "name"
+    }
+  ],
+  "Header": {
+    "InputOntologies": [
+      {
+        "DtdlVersion": "v2",
+        "Name": "rec",
+        "Version": "1.0"
+      }
+    ],
+    "OutputOntologies": [
+      {
+        "DtdlVersion": "v3",
+        "Name": "willow",
+        "Version": "1.0"
+      }
+    ]
+  },
+  "InterfaceRemaps": [
+    {
+      "InputDtmi": "dtmi:org:w3id:rec:Lease;1",
+      "OutputDtmi": "dtmi:com:willowinc:Lease;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:w3id:rec:Organization;1",
+      "OutputDtmi": "dtmi:com:willowinc:Organization;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:w3id:rec:Company;1",
+      "OutputDtmi": "dtmi:com:willowinc:Company;1"
+    }
+  ],
+  "NamespaceRemaps": [
+  ],
+  "ObjectTransformations": [
+  ],
+  "PropertyProjections": [
+  ],
+  "RelationshipRemaps": [
+  ]
+}

--- a/Ontologies.Mappings/src/MultifileOntologyMappingLoader.cs
+++ b/Ontologies.Mappings/src/MultifileOntologyMappingLoader.cs
@@ -1,0 +1,134 @@
+﻿// <copyright file="MultifileOntologyMappingLoader.cs" company="Mapped">
+// Copyright (c) Mapped. All rights reserved.
+// </copyright>
+
+namespace Mapped.Ontologies.Mappings.OntologyMapper.Mapped
+{
+    using System.Reflection;
+    using System.Text.Json;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Ontology mapping loader implementation that loads mappings from a
+    /// resource file embedded within the assembly.
+    /// </summary>
+    public class MultifileOntologyMappingLoader : IOntologyMappingLoader
+    {
+        private readonly ILogger logger;
+        private readonly List<string> resourcePaths;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultifileOntologyMappingLoader"/> class.
+        /// </summary>
+        /// <param name="logger">Logging implementation.</param>
+        /// <param name="resourcePaths">Paths to ontology mappings file embedded within assembly, using dot notation, e.g., <em>Mappings.v0.BrickRec.mapped_json_v0_dtdlv2_Brick_1_3-REC_4_0.json</em>.</param>
+        public MultifileOntologyMappingLoader(ILogger logger, List<string> resourcePaths)
+        {
+            if (resourcePaths == null || !resourcePaths.Any())
+            {
+                throw new ArgumentNullException(nameof(resourcePaths));
+            }
+
+            this.logger = logger;
+            this.resourcePaths = resourcePaths;
+        }
+
+        /// <inheritdoc/>
+        public OntologyMapping LoadOntologyMapping()
+        {
+            OntologyMapping? mappings = null;
+
+            foreach (var resourcePath in resourcePaths)
+            {
+                logger.LogInformation("Loading Ontology Mapping file: {fileName}", resourcePath);
+
+                var assembly = Assembly.GetExecutingAssembly();
+                var resources = assembly.GetManifestResourceNames();
+                var resourceName = resources.Single(str => str.ToLowerInvariant().EndsWith(resourcePath.ToLowerInvariant()));
+
+                var options = new JsonSerializerOptions
+                {
+                    ReadCommentHandling = JsonCommentHandling.Skip,
+                };
+
+                using (Stream? stream = assembly.GetManifestResourceStream(resourceName))
+                {
+                    if (stream != null)
+                    {
+                        using (StreamReader reader = new StreamReader(stream))
+                        {
+                            string result = reader.ReadToEnd();
+                            try
+                            {
+                                var innerMappings = JsonSerializer.Deserialize<OntologyMapping>(result, options);
+
+                                mappings = MergeMappings(mappings, innerMappings);
+                            }
+                            catch (JsonException jex)
+                            {
+                                throw new MappingFileException($"Mappings file '{resourcePath}' is malformed.", resourcePath, jex);
+                            }
+
+                            if (mappings == null)
+                            {
+                                throw new MappingFileException($"Mappings file '{resourcePath}' is empty.", resourcePath);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        throw new FileNotFoundException(resourcePath);
+                    }
+                }
+            }
+
+            return mappings ?? new OntologyMapping();
+        }
+
+        private static OntologyMapping? MergeMappings(OntologyMapping? mappings, OntologyMapping? mappingsToMerge)
+        {
+            if (mappings == null)
+            {
+                return mappingsToMerge;
+            }
+
+            if (mappingsToMerge != null)
+            {
+                // These type of mappings should never result in duplicates. If they do, that will cause test failures before check-in.
+                mappings.InterfaceRemaps.AddRange(mappingsToMerge.InterfaceRemaps);
+                mappings.RelationshipRemaps.AddRange(mappingsToMerge.RelationshipRemaps);
+                var propertyProjectionComparer = new PropertyProjectionComparer();
+                var objectTransformationComparer = new ObjectTransformationComparer();
+                var fillPropertyComparer = new FillPropertyComparer();
+
+                // Property Projections may result in duplicates. Remove dupes.
+                foreach (var mapping in mappingsToMerge.PropertyProjections)
+                {
+                    if (!mappings.PropertyProjections.Contains(mapping, propertyProjectionComparer))
+                    {
+                        mappings.PropertyProjections.Add(mapping);
+                    }
+                }
+
+                // Object Transformations may result in duplicates. Remove dupes.
+                foreach (var mapping in mappingsToMerge.ObjectTransformations)
+                {
+                    if (!mappings.ObjectTransformations.Contains(mapping, objectTransformationComparer))
+                    {
+                        mappings.ObjectTransformations.Add(mapping);
+                    }
+                }
+
+                foreach (var mapping in mappingsToMerge.FillProperties)
+                {
+                    if (!mappings.FillProperties.Contains(mapping, fillPropertyComparer))
+                    {
+                        mappings.FillProperties.Add(mapping);
+                    }
+                }
+            }
+
+            return mappings;
+        }
+    }
+}

--- a/Ontologies.Mappings/src/ObjectTransformationComparer.cs
+++ b/Ontologies.Mappings/src/ObjectTransformationComparer.cs
@@ -1,0 +1,44 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ObjectTransformationComparer.cs" company="Mapped">
+// Copyright (c) Mapped. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Mapped.Ontologies.Mappings
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Mapped.Ontologies.Mappings.OntologyMapper;
+
+    /// <summary>
+    /// Compares to Property Projections for equality.
+    /// </summary>
+    internal class ObjectTransformationComparer : IEqualityComparer<ObjectTransformation>
+    {
+        /// <summary>
+        /// Compares two Property Projections for equality.
+        /// </summary>
+        /// <param name="x">Input Property Projection 1.</param>
+        /// <param name="y">Input Property Projection 2.</param>
+        /// <returns>Returns true if equal, false if not.</returns>
+        public bool Equals(ObjectTransformation? x, ObjectTransformation? y)
+        {
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            if (x.InputPropertyName != y.InputPropertyName || x.OutputPropertyName != y.OutputPropertyName || x.OutputDtmiFilter != y.OutputDtmiFilter)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public int GetHashCode([DisallowNull] ObjectTransformation obj)
+        {
+            return (obj.InputPropertyName + obj.OutputPropertyName + obj.OutputDtmiFilter).GetHashCode();
+        }
+    }
+}

--- a/Ontologies.Mappings/src/Ontologies.Mappings.csproj
+++ b/Ontologies.Mappings/src/Ontologies.Mappings.csproj
@@ -25,6 +25,7 @@
 	<ItemGroup>
 	  <None Remove="Mappings\v1\Willow\Brick_to_WillowInc.json" />
 	  <None Remove="Mappings\v1\Willow\Mapped.Core_to_WillowInc.json" />
+	  <None Remove="Mappings\v1\Willow\Mapped_to_WillowInc_Generic.json" />
 	  <None Remove="Mappings\v1\Willow\Rec_to_WillowInc.json" />
 	</ItemGroup>
 	

--- a/Ontologies.Mappings/src/Ontologies.Mappings.csproj
+++ b/Ontologies.Mappings/src/Ontologies.Mappings.csproj
@@ -23,6 +23,12 @@
 	</ItemGroup>
 	
 	<ItemGroup>
+	  <None Remove="Mappings\v1\Willow\Brick_to_WillowInc.json" />
+	  <None Remove="Mappings\v1\Willow\Mapped.Core_to_WillowInc.json" />
+	  <None Remove="Mappings\v1\Willow\Rec_to_WillowInc.json" />
+	</ItemGroup>
+	
+	<ItemGroup>
 		<PackageReference Include="DTDLParser" Version="1.0.52" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/Ontologies.Mappings/src/PropertyProjectionComparer.cs
+++ b/Ontologies.Mappings/src/PropertyProjectionComparer.cs
@@ -1,0 +1,55 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PropertyProjectionComparer.cs" company="Mapped">
+// Copyright (c) Mapped. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Mapped.Ontologies.Mappings
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Mapped.Ontologies.Mappings.OntologyMapper;
+
+    /// <summary>
+    /// Compares to Property Projections for equality.
+    /// </summary>
+    internal class PropertyProjectionComparer : IEqualityComparer<PropertyProjection>
+    {
+        /// <summary>
+        /// Compares two Property Projections for equality.
+        /// </summary>
+        /// <param name="x">Input Property Projection 1.</param>
+        /// <param name="y">Input Property Projection 2.</param>
+        /// <returns>Returns true if equal, false if not.</returns>
+        public bool Equals(PropertyProjection? x, PropertyProjection? y)
+        {
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            foreach (var inputName in x.InputPropertyNames)
+            {
+                if (!y.InputPropertyNames.Contains(inputName))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var inputName in y.InputPropertyNames)
+            {
+                if (!x.InputPropertyNames.Contains(inputName))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public int GetHashCode([DisallowNull] PropertyProjection obj)
+        {
+            return obj.InputPropertyNames.OrderBy(x => x).GetHashCode();
+        }
+    }
+}

--- a/Ontologies.Mappings/test/MultipleFileMappingValidationTests.cs
+++ b/Ontologies.Mappings/test/MultipleFileMappingValidationTests.cs
@@ -20,7 +20,8 @@ namespace Mapped.Ontologies.Mappings.OntologyMapper.Mapped.Test
         [InlineData("Mappings.v1.Willow.Brick_to_WillowInc.json")]
         [InlineData("Mappings.v1.Willow.Mapped.Core_to_WillowInc.json")]
         [InlineData("Mappings.v1.Willow.Rec_to_WillowInc.json")]
-        [InlineData("Mappings.v1.Willow.Rec_to_WillowInc.json", "Mappings.v1.Willow.Mapped.Core_to_WillowInc.json", "Mappings.v1.Willow.Brick_to_WillowInc.json")]
+        [InlineData("Mappings.v1.Willow.Mapped_to_WillowInc_Generic.json")]
+        [InlineData("Mappings.v1.Willow.Rec_to_WillowInc.json", "Mappings.v1.Willow.Mapped.Core_to_WillowInc.json", "Mappings.v1.Willow.Brick_to_WillowInc.json", "Mappings.v1.Willow.Mapped_to_WillowInc_Generic.json")]
         public void ValidateMappedDtmisAreValidFormat(params string[] resourcePaths)
         {
             var mockLogger = new Mock<ILogger>();


### PR DESCRIPTION
### What
Splitting mappings files

### Why
Allows each different instance of apps that consume the mappings files to only include the mappings of the extensions they need, instead of extra extensions that aren't relevant.

### Tested
Ran unit tests