### PR TITLE
Correct Willow's shower mapping

### DIFF
--- a/Ontologies.Mappings/src/Mappings/v1/Mapped/willow_v1_dtdlv2_mapped.json
+++ b/Ontologies.Mappings/src/Mappings/v1/Mapped/willow_v1_dtdlv2_mapped.json
@@ -3314,7 +3314,7 @@
     },
     {
       "InputDtmi": "dtmi:com:willowinc:Shower;1",
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Shower;1"
+      "OutputDtmi": "dtmi:mapped:core:Plumbing_Equipment;1"
     },
     {
       "InputDtmi": "dtmi:com:willowinc:SmokeDamper;1",


### PR DESCRIPTION
### What
Correcting Willow's shower mapping

### Why
Willow considers a shower to be equipment, whereas Brick considers it a space
