### PR TITLE
Updating mappings to fix fan issue

### DIFF
--- a/Ontologies.Mappings/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
+++ b/Ontologies.Mappings/src/Mappings/v1/Willow/mapped_v1_dtdlv2_Willow.json
@@ -1080,7 +1080,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Booster_Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Box_Mode_Command;1",
@@ -1476,7 +1476,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Tower_Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Valve;1",
@@ -2160,7 +2160,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan_Command;1",
@@ -3684,7 +3684,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Relief_Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Remotely_On_Off_Status;1",
@@ -3948,7 +3948,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Standby_Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Standby_Glycool_Unit_On_Off_Status;1",

--- a/Ontologies.Mappings/test/Ontologies.Mappings.Test.csproj
+++ b/Ontologies.Mappings/test/Ontologies.Mappings.Test.csproj
@@ -21,7 +21,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
-		<PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.27.7" />
+		<PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.27.17" />
 		<PackageReference Include="RealEstateCore.Ontology.DTDLv2" Version="4.0.0.19" />
 		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
@@ -29,7 +29,7 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 		<PackageReference Include="WillowInc.Ontology.Airport.DTDLv3" Version="1.0.0.3" />
-		<PackageReference Include="WillowInc.Ontology.DTDLv3" Version="1.0.1.18" />
+		<PackageReference Include="WillowInc.Ontology.DTDLv3" Version="1.0.1.26" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### What
Updating mappings to fix fan issue

### Why
dtmi:com:willowinc:Fan;1 is considered a Component in our ontology (essentially an abstract class) so should never be directly used in the mappings. Instead, we should use HVACFan;1 for mapping from Brick Fan;1.

### Tested
