### PR TITLE
Updated dtmi:com:willowinc:Fan;1 to dtmi:com:willowinc:HVACFan;1 where necessary

### DIFF
--- a/Ontologies.Mappings/src/Mappings/v1/Mapped/Willow2Mapped.json
+++ b/Ontologies.Mappings/src/Mappings/v1/Mapped/Willow2Mapped.json
@@ -17792,33 +17792,9 @@
       "IsInferred": false
     },
     {
-      "InputDtmi": "dtmi:com:willowinc:airport:AirportAsset;1",
-      "OutputDtmi": "dtmi:mapped:core:Asset_Tag;1",
-      "Confidence": 0.28,
-      "IsInferred": true
-    },
-    {
-      "InputDtmi": "dtmi:com:willowinc:airport:AirportAssetCollection;1",
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Collection;1",
-      "Confidence": 0.33,
-      "IsInferred": true
-    },
-    {
       "InputDtmi": "dtmi:com:willowinc:airport:AirportAudioVisualEquipment;1",
       "OutputDtmi": "dtmi:mapped:core:Audio_Visual_Equipment;1",
       "Confidence": 0.75,
-      "IsInferred": true
-    },
-    {
-      "InputDtmi": "dtmi:com:willowinc:airport:AirportCapability;1",
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Point;1",
-      "Confidence": 0.1,
-      "IsInferred": true
-    },
-    {
-      "InputDtmi": "dtmi:com:willowinc:airport:AirportCollection;1",
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Collection;1",
-      "Confidence": 0.5,
       "IsInferred": true
     },
     {
@@ -17831,12 +17807,6 @@
       "InputDtmi": "dtmi:com:willowinc:airport:AirportEquipment;1",
       "OutputDtmi": "dtmi:mapped:core:Automotive_Equipment;1",
       "Confidence": 0.28,
-      "IsInferred": true
-    },
-    {
-      "InputDtmi": "dtmi:com:willowinc:airport:AirportEquipmentCollection;1",
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Collection;1",
-      "Confidence": 0.33,
       "IsInferred": true
     },
     {

--- a/Ontologies.Mappings/test/MappedMappingValidationTests.cs
+++ b/Ontologies.Mappings/test/MappedMappingValidationTests.cs
@@ -179,7 +179,7 @@ namespace Mapped.Ontologies.Mappings.OntologyMapper.Mapped.Test
 
             var ontologyMappingManager = new OntologyMappingManager(resourceLoader);
             var modelParser = new ModelParser();
-            var inputDtmi = LoadDtdl("Willow.Ontology.Airport.DTDLv3.jsonld");
+            var inputDtmi = LoadDtdl("Willow.Ontology.DTDLv3.jsonld");
             var inputModels = modelParser.Parse(inputDtmi);
             ontologyMappingManager.ValidateSourceOntologyMapping(inputModels, out var invalidSources);
             Console.WriteLine(invalidSources.Count());

--- a/Ontologies.Mappings/test/Ontologies.Mappings.Test.csproj
+++ b/Ontologies.Mappings/test/Ontologies.Mappings.Test.csproj
@@ -21,14 +21,14 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
-		<PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.48.0" />
+		<PackageReference Include="Mapped.Ontologies.Core.Dtdl" Version="1.50.30" />
 		<PackageReference Include="RealEstateCore.Ontology.DTDLv2" Version="4.0.0.19" />
 		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
 		<PackageReference Include="Moq" Version="4.18.2" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-		<PackageReference Include="WillowInc.Ontology.Airport.DTDLv3" Version="1.0.0.10" />
+		<PackageReference Include="WillowInc.Ontology.DTDLv3" Version="1.0.1.92" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Ontologies.Mappings/test/WillowMappingValidationTests.cs
+++ b/Ontologies.Mappings/test/WillowMappingValidationTests.cs
@@ -211,7 +211,7 @@ namespace Mapped.Ontologies.Mappings.OntologyMapper.Mapped.Test
 
             var ontologyMappingManager = new OntologyMappingManager(resourceLoader);
             var modelParser = new ModelParser();
-            var inputDtmi = LoadDtdl(new[] { "Willow.Ontology.Airport.DTDLv3.jsonld" });
+            var inputDtmi = LoadDtdl(new[] { "Willow.Ontology.DTDLv3.jsonld" });
 
             var inputModels = modelParser.Parse(inputDtmi);
             ontologyMappingManager.ValidateTargetOntologyMapping(inputModels, out var invalidSources);
@@ -232,7 +232,7 @@ namespace Mapped.Ontologies.Mappings.OntologyMapper.Mapped.Test
 
             var ontologyMappingManager = new OntologyMappingManager(resourceLoader);
             var modelParser = new ModelParser();
-            var inputDtmi = LoadDtdl(new[] { "Willow.Ontology.Airport.DTDLv3.jsonld" });
+            var inputDtmi = LoadDtdl(new[] { "Willow.Ontology.DTDLv3.jsonld" });
 
             List<string> invalidSources = new List<string>();
             try

--- a/data/Mapped2Willow.json
+++ b/data/Mapped2Willow.json
@@ -4531,6 +4531,10 @@
       "OutputDtmi": "dtmi:com:willowinc:RunState;1"
     },
     {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:RVAV;1",
+      "OutputDtmi": "dtmi:com:willowinc:VAVBoxReheat;1"
+    },
+    {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Safety_Equipment;1",
       "OutputDtmi": "dtmi:com:willowinc:SafetyEquipment;1"
     },
@@ -5171,8 +5175,16 @@
       "OutputDtmi": "dtmi:com:willowinc:VAVBox;1"
     },
     {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:Variable_Air_Volume_Box_With_Reheat;1",
+      "OutputDtmi": "dtmi:com:willowinc:VAVBoxReheat;1"
+    },
+    {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Variable_Frequency_Drive;1",
       "OutputDtmi": "dtmi:com:willowinc:VariableFrequencyDrive;1"
+    },
+    {
+      "InputDtmi": "dtmi:org:brickschema:schema:Brick:VAV;1",
+      "OutputDtmi": "dtmi:com:willowinc:VAVBox;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Velocity_Pressure_Sensor;1",

--- a/data/Mapped2Willow.json
+++ b/data/Mapped2Willow.json
@@ -1772,7 +1772,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Booster_Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Box_Mode_Command;1",
@@ -2172,7 +2172,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Tower_Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Cooling_Valve;1",
@@ -2824,7 +2824,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Fan_Coil_Unit;1",
@@ -4400,7 +4400,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Relief_Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Remotely_On_Off_Status;1",
@@ -4680,7 +4680,7 @@
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Standby_Fan;1",
-      "OutputDtmi": "dtmi:com:willowinc:Fan;1"
+      "OutputDtmi": "dtmi:com:willowinc:HVACFan;1"
     },
     {
       "InputDtmi": "dtmi:org:brickschema:schema:Brick:Standby_Glycool_Unit_On_Off_Status;1",

--- a/data/Willow2Mapped.json
+++ b/data/Willow2Mapped.json
@@ -1501,10 +1501,6 @@
       "OutputDtmi": "dtmi:mapped:core:Entity;1"
     },
     {
-      "InputDtmi": "dtmi:com:willowinc:Fan;1",
-      "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Fan;1"
-    },
-    {
       "InputDtmi": "dtmi:com:willowinc:FanCoilUnit;1",
       "OutputDtmi": "dtmi:org:brickschema:schema:Brick:Fan_Coil_Unit;1"
     },


### PR DESCRIPTION
### What
- Updated references to dtmi:com:willowinc:Fan;1 to point to dtmi:com:willowinc:HVACFan;1 in the Mapped2Willow file.
- In Willow2Mapped, removed mapping from dtmi:com:willowinc:Fan;1 to dtmi:org:brickschema:schema:Brick:Fan;1 because mapping from dtmi:com:willowinc:HVACFan;1 to dtmi:org:brickschema:schema:Brick:Fan;1 already exists.
- Added Brick RVAV to Willow VAVBoxReheat mapping in the Mapped2Willow file.
- Added Brick Variable Air Volume Box with Reheat to Willow VAVBoxReheat mapping in the Mapped2Willow file.
- Added Brick VAV to Willow VAVBox mapping in the Mapped2Willow file.

### Why
To function more accurately with the Willow ontology

### Tested
